### PR TITLE
fix: Mode B config with connected: sensor incorrectly fails with "ble_client_id is required"

### DIFF
--- a/esphome/components/philips_sonicare/__init__.py
+++ b/esphome/components/philips_sonicare/__init__.py
@@ -67,9 +67,6 @@ _BASE_SCHEMA = cv.Schema(
 ).extend(cv.COMPONENT_SCHEMA)
 
 # Mode A: external ble_client (backward compatible) — Worker is PhilipsSonicare.
-# `ble_client_id` is Required (not GenerateID) so cv.Any can cleanly route a
-# config without it to _INTERNAL_SCHEMA. With GenerateID + use_id the deferred
-# lookup fires after schema match and bypasses cv.Any's fallback.
 _EXTERNAL_SCHEMA = _BASE_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(PhilipsSonicare),
@@ -100,10 +97,23 @@ def _internal_set_defaults(config):
     return config
 
 
-CONFIG_SCHEMA = cv.Any(
-    _EXTERNAL_SCHEMA,
-    cv.All(_INTERNAL_SCHEMA, _internal_set_defaults),
-)
+def _validate_config(config):
+    # Route to the appropriate schema based on the user's keys before any
+    # schema runs. Previously this used cv.Any(_EXTERNAL_SCHEMA, cv.All(_INTERNAL_SCHEMA, ...)),
+    # but nested schemas with deferred-ID generation (e.g. binary_sensor_schema
+    # inside `connected:`) pollute cv.Any's backtracking — when Mode A's
+    # validation attempt fires the deferred declare_id, Mode B can no longer
+    # be entered cleanly and cv.Any reports Mode A's error verbatim.
+    #
+    # Explicit routing avoids backtracking entirely: presence of `ble_client_id`
+    # selects Mode A, absence selects Mode B. Each schema then runs exactly
+    # once against a fresh config dict.
+    if CONF_BLE_CLIENT_ID in config:
+        return _EXTERNAL_SCHEMA(config)
+    return cv.All(_INTERNAL_SCHEMA, _internal_set_defaults)(config)
+
+
+CONFIG_SCHEMA = _validate_config
 
 _instance_count = 0
 


### PR DESCRIPTION
## Bug

A Mode B (Auto-Discovery) config that includes the `connected:` binary sensor
fails validation with an error from Mode A:

    Invalid value for option in philips_sonicare component: 'ble_client_id' is a required option

## Reproduction

ESPHome 2026.4.5, Mode B (Auto-Discovery — no `ble_client:` block).

### Fails: Mode B with `connected:` sensor

```yaml
philips_sonicare:
  - id: brush_black
    bridge_id: black
    connected:
      name: "Black Sonicare Connected"
    on_connect:
      then:
        - logger.log: "connected"
    on_disconnect:
      then:
        - logger.log: "disconnected"
```

```yaml
# bridge_id omitted — same error
philips_sonicare:
  - id: brush_black
    connected:
      name: "Black Sonicare Connected"
    on_connect:
      then:
        - logger.log: "connected"
    on_disconnect:
      then:
        - logger.log: "disconnected"
```

Error in both cases:

    Invalid value for option in philips_sonicare component: 'ble_client_id' is a required option

The error is misleading — there is no `ble_client_id` in this config, nor should
there be. Removing `connected:` makes the config validate and compile correctly.

### Works: same config without `connected:`

```yaml
philips_sonicare:
  - id: brush_black
    bridge_id: black
    on_connect:
      then:
        - logger.log: "connected"
    on_disconnect:
      then:
        - logger.log: "disconnected"
```

```yaml
# bridge_id omitted — also works
philips_sonicare:
  - id: brush_black
    on_connect:
      then:
        - logger.log: "connected"
    on_disconnect:
      then:
        - logger.log: "disconnected"
```

### Works: Mode A with `connected:` (unaffected by this bug)

```yaml
ble_client:
  - id: black_ble
    mac_address: "AA:BB:CC:DD:EE:FF"

philips_sonicare:
  - ble_client_id: black_ble
    connected:
      name: "Black Sonicare Connected"
```

## Root cause

`CONFIG_SCHEMA = cv.Any(_EXTERNAL_SCHEMA, cv.All(_INTERNAL_SCHEMA, ...))` tries
Mode A first. During that attempt, the deferred ID generation inside
`binary_sensor.binary_sensor_schema()` (used by the `connected:` field in
`_BASE_SCHEMA`) fires and registers a declaration. After that side-effect, Mode B
can no longer be entered cleanly, so `cv.Any` reports Mode A's error verbatim.

This is the same class of bug already fixed for `ble_client_id` itself —
making it `Required` instead of `GenerateID` so `cv.Any`'s fallback works. The
`connected:` field's nested schema wasn't caught by that workaround because it
lives in the shared `_BASE_SCHEMA`, not in `_EXTERNAL_SCHEMA`.

## Fix

Replace `cv.Any` with `_validate_config()`, a callable that inspects the raw
config keys *before* any schema runs:

- `ble_client_id` present → Mode A (`_EXTERNAL_SCHEMA`)
- absent → Mode B (`cv.All(_INTERNAL_SCHEMA, _internal_set_defaults)`)

No backtracking, no deferred-lookup pollution. Each schema runs exactly once
against a fresh config dict. `to_code` is untouched. `_internal_set_defaults`
is preserved. Mode A behaviour is unchanged.

---

*Generated with Claude Code, human-reviewed.*