### PR TITLE
perf(esphome): shave Sonicare reconnect lag from ~7-8s to ~2-3s

### DIFF
--- a/custom_components/philips_sonicare_ble/transport.py
+++ b/custom_components/philips_sonicare_ble/transport.py
@@ -745,13 +745,18 @@ class EspBridgeTransport(SonicareTransport):
     async def read_chars(self, char_uuids: list[str]) -> dict[str, bytes | None]:
         if not self._setup_done:
             await self.connect()
-        results: dict[str, bytes | None] = {}
-        for uuid in char_uuids:
-            if not self.is_connected:
-                results[uuid] = None
-                continue
-            results[uuid] = await self.read_char(uuid)
-        return results
+        if not char_uuids:
+            return {}
+        if not self.is_connected:
+            return {u: None for u in char_uuids}
+
+        # Fire all reads at once — the bridge serialises GATT ops via its
+        # pending-calls queue (drained one at a time on each read completion),
+        # so we get back-to-back BLE reads without HA-loop overhead between
+        # them. read_char never raises (returns None on failure) so a bare
+        # gather is safe.
+        results = await asyncio.gather(*(self.read_char(u) for u in char_uuids))
+        return dict(zip(char_uuids, results))
 
     async def write_char(self, char_uuid: str, data: bytes) -> None:
         if not self._setup_done:

--- a/docs/ESP32_BRIDGE.md
+++ b/docs/ESP32_BRIDGE.md
@@ -335,7 +335,10 @@ drawbacks:
 
 This dedicated Bridge component manages the GATT connection directly on
 the ESP32 with its own pairing stack, notification throttle, and
-per-device subscription state — avoiding all three issues.
+per-device subscription state — avoiding all three issues. Reconnects
+on a bonded brush also eagerly initiate SMP encryption (rather than
+discovering the need via a probe read), so the handshake overlaps with
+the post-SDP read pass instead of serialising behind it.
 
 ## Troubleshooting
 

--- a/docs/ESP32_BRIDGE.md
+++ b/docs/ESP32_BRIDGE.md
@@ -340,6 +340,21 @@ on a bonded brush also eagerly initiate SMP encryption (rather than
 discovering the need via a probe read), so the handshake overlaps with
 the post-SDP read pass instead of serialising behind it.
 
+### Persisted GATT cache (optional)
+
+Setting `CONFIG_BT_GATTC_CACHE_NVS_FLASH: "y"` under `esp32.framework.sdkconfig_options`
+persists the discovered GATT table to NVS keyed by the bonded peer's
+identity. The first connect after a flash or unpair still runs the full
+~4 s SDP; subsequent reconnects to the same brush hit the cache in tens
+of ms and skip discovery entirely. On a brush you reconnect to often,
+this is the biggest single contributor to reconnect latency.
+
+The cache-save path in ESP-IDF 5.5's Bluedroid has the same NULL deref
+as the `bluetooth_proxy` coexistence bug, so this flag depends on the
+[Bluedroid NULL-check patch](../esphome/README.md#bluedroid-null-check-patch-bluedroid_null_fixpy).
+Disable the flag if you'd rather skip the patch — the bridge still
+works, just runs the full SDP on every wake.
+
 ## Troubleshooting
 
 ### ESP32 crashes/reboots when connecting

--- a/docs/ESP32_PROTOCOL.md
+++ b/docs/ESP32_PROTOCOL.md
@@ -189,7 +189,7 @@ Read a GATT characteristic on the bonded brush.
 | | |
 |---|---|
 | **Args** | `service_uuid: string`, `char_uuid: string` |
-| **Side-effect** | Issues an `esp_ble_gattc_read_char`. On `INSUF_AUTH/ENCR` it transparently triggers SMP and retries the read once `AUTH_CMPL` succeeds (auto-retry behavior added in 1.3.0). |
+| **Side-effect** | Issues an `esp_ble_gattc_read_char`. On `INSUF_AUTH/ENCR` it transparently triggers SMP and retries the read once `AUTH_CMPL` succeeds (auto-retry behavior added in 1.3.0). Concurrent reads that race the SMP handshake — common when HA fires its initial poll over `read_chars` — are requeued via the bridge's pending-calls queue and drained on `AUTH_CMPL` (added in <!-- BRIDGE_VERSION -->1.5.0). |
 | **Reply** | `_ble_data` event |
 
 **`_ble_data` (success):**

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -14,6 +14,11 @@ proxy path works. See [Option C: Bluetooth Proxy](../README.md#option-c-bluetoot
 in the main README for scope and limitations of the proxy path compared to
 the dedicated [ESP32 BLE Bridge](ESP32_BRIDGE.md).
 
+The same patch also unlocks an optional bridge performance setting
+([`CONFIG_BT_GATTC_CACHE_NVS_FLASH`](ESP32_BRIDGE.md#persisted-gatt-cache-optional))
+that depends on the same NULL guards. The flag is off in a stock build
+and only relevant if you enable it explicitly.
+
 ### Symptoms
 
 - ESP32 reboots every ~20 seconds in a loop

--- a/esphome/README.md
+++ b/esphome/README.md
@@ -56,7 +56,22 @@ script is harmless to leave in place — it becomes a no-op against patched
 source.
 
 **If you only run this bridge and no `bluetooth_proxy:`, the patch is not
-required.**
+required** — unless you also opt into the persisted GATT cache (next
+section), which depends on the same NULL guards.
+
+## Persisted GATT cache (optional)
+
+Adding `CONFIG_BT_GATTC_CACHE_NVS_FLASH: "y"` under `sdkconfig_options`
+persists the discovered GATT table to NVS keyed by the bonded peer's
+identity. With it, the first connect to a bonded brush still does a
+full ~4 s service discovery; subsequent reconnects hit the cached
+service table in tens of ms. On a brush you reconnect to often this is
+the biggest single contributor to reconnect latency.
+
+The cache-save path crashes on the same NULL deref as the proxy bug, so
+this flag depends on the patch above. To opt in, uncomment the
+`CONFIG_BT_GATTC_CACHE_NVS_FLASH` line in your YAML (and the patch
+wiring at the top of `esphome:` if not already enabled).
 
 ## Requirements
 

--- a/esphome/atom-lite-dual.yaml
+++ b/esphome/atom-lite-dual.yaml
@@ -1,8 +1,14 @@
 esphome:
   name: atom-lite
   friendly_name: "Atom Lite BLE Bridge"
-  # Uncomment to enable bluetooth_proxy (requires bluedroid_null_fix.py
-  # in your ESPHome config directory — see bottom of this file):
+  # Optional: bluedroid_null_fix.py cherry-picks the NULL pointer guards
+  # from ESP-IDF commit d4f3517 into the build. Uncomment the
+  # platformio_options block below if you opt into either:
+  #   - CONFIG_BT_GATTC_CACHE_NVS_FLASH (see sdkconfig_options below)
+  #   - bluetooth_proxy: (see end of file)
+  # Both crash on ESP-IDF 5.5's bluedroid GATT cache path without the
+  # patch. Place the script next to this YAML in your ESPHome config dir.
+  #
   # platformio_options:
   #   extra_scripts:
   #     - pre:/config/esphome/bluedroid_null_fix.py
@@ -17,6 +23,13 @@ esp32:
     sdkconfig_options:
       CONFIG_BT_GATTC_MAX_CACHE_CHAR: "160"    # default 40; Sonicare has ~45 attributes
       CONFIG_BT_GATTC_NOTIF_REG_MAX: "30"      # default 5; we subscribe to 11 chars per device
+      # Optional: persist discovered GATT DB to NVS keyed by bonded peer
+      # identity. First connect still does a full ~4s SDP; subsequent
+      # reconnects to the same brush hit the cache in tens of ms. Requires
+      # the bluedroid_null_fix.py pre-script (uncomment platformio_options
+      # at the top of this file) — without it the cache-save path crashes
+      # inside bta_gattc_cache_save on ESP-IDF 5.5.
+      # CONFIG_BT_GATTC_CACHE_NVS_FLASH: "y"
 
 logger:
   level: DEBUG
@@ -129,14 +142,11 @@ binary_sensor:
       inverted: true
 
 # --- Bluetooth Proxy (optional) ---
-# bluetooth_proxy requires a workaround for ESP-IDF bug
-# https://github.com/esphome/esphome/issues/15783
-#
-# To enable, uncomment bluetooth_proxy below AND add the pre-build
-# patch to esphome: platformio_options (see top of this file).
-# The patch fixes a NULL pointer crash in the Bluedroid BLE stack
-# that occurs during GATT service discovery when bluetooth_proxy
-# registers multiple GATT client interfaces.
+# Uncomment to relay BLE for other devices through this ESP. Requires the
+# bluedroid_null_fix.py patch (uncomment platformio_options at the top of
+# this file) to dodge ESP-IDF bug
+# https://github.com/esphome/esphome/issues/15783 — without the patch,
+# every GATT service discovery crashes the chip.
 #
 # bluetooth_proxy:
 #   active: true

--- a/esphome/atom-lite.yaml
+++ b/esphome/atom-lite.yaml
@@ -1,8 +1,14 @@
 esphome:
   name: atom-lite
   friendly_name: "Atom Lite BLE Bridge"
-  # Uncomment to enable bluetooth_proxy (requires bluedroid_null_fix.py
-  # in your ESPHome config directory — see bottom of this file):
+  # Optional: bluedroid_null_fix.py cherry-picks the NULL pointer guards
+  # from ESP-IDF commit d4f3517 into the build. Uncomment the
+  # platformio_options block below if you opt into either:
+  #   - CONFIG_BT_GATTC_CACHE_NVS_FLASH (see sdkconfig_options below)
+  #   - bluetooth_proxy: (see end of file)
+  # Both crash on ESP-IDF 5.5's bluedroid GATT cache path without the
+  # patch. Place the script next to this YAML in your ESPHome config dir.
+  #
   # platformio_options:
   #   extra_scripts:
   #     - pre:/config/esphome/bluedroid_null_fix.py
@@ -17,6 +23,13 @@ esp32:
     sdkconfig_options:
       CONFIG_BT_GATTC_MAX_CACHE_CHAR: "80"    # default 40; Sonicare has ~45 attributes
       CONFIG_BT_GATTC_NOTIF_REG_MAX: "20"     # default 5; we subscribe to 11 chars
+      # Optional: persist discovered GATT DB to NVS keyed by bonded peer
+      # identity. First connect still does a full ~4s SDP; subsequent
+      # reconnects to the same brush hit the cache in tens of ms. Requires
+      # the bluedroid_null_fix.py pre-script (uncomment platformio_options
+      # at the top of this file) — without it the cache-save path crashes
+      # inside bta_gattc_cache_save on ESP-IDF 5.5.
+      # CONFIG_BT_GATTC_CACHE_NVS_FLASH: "y"
 
 logger:
   level: DEBUG
@@ -120,14 +133,11 @@ binary_sensor:
       inverted: true
 
 # --- Bluetooth Proxy (optional) ---
-# bluetooth_proxy requires a workaround for ESP-IDF bug
-# https://github.com/esphome/esphome/issues/15783
-#
-# To enable, uncomment bluetooth_proxy below AND add the pre-build
-# patch to esphome: platformio_options (see top of this file).
-# The patch fixes a NULL pointer crash in the Bluedroid BLE stack
-# that occurs during GATT service discovery when bluetooth_proxy
-# registers multiple GATT client interfaces.
+# Uncomment to relay BLE for other devices through this ESP. Requires the
+# bluedroid_null_fix.py patch (uncomment platformio_options at the top of
+# this file) to dodge ESP-IDF bug
+# https://github.com/esphome/esphome/issues/15783 — without the patch,
+# every GATT service discovery crashes the chip.
 #
 # bluetooth_proxy:
 #   active: true

--- a/esphome/components/philips_sonicare/coordinator.cpp
+++ b/esphome/components/philips_sonicare/coordinator.cpp
@@ -579,10 +579,16 @@ void SonicareCoordinator::on_gattc_event(esp_gattc_cb_event_t event,
       }
       // Pairing probe.
       //
-      // Classic (Sonicare service 477ea600-…): read Handle State (0x4010).
-      // The read either succeeds (open-GATT brushes like HX6340 Kids) or
-      // returns INSUF_AUTHENTICATION (bonded brushes like HX9992) which
-      // we use as the SMP trigger.
+      // Classic (Sonicare service 477ea600-…) bonded peer: skip the probe
+      // read entirely and trigger SMP encryption directly. The Sonicare
+      // re-keys the link on every fresh GATT connection even though both
+      // sides hold the bond — without eager encryption, HA's post-ready
+      // initial-poll reads race the SMP handshake and get dropped (only
+      // one of them gets retried via retry_read_after_auth_).
+      //
+      // Classic open-GATT peer (HX6340 Kids etc.) OR not-yet-bonded peer:
+      // still do the probe read. A success means open-GATT (no encryption
+      // needed); INSUF_AUTH triggers the existing pairing flow.
       //
       // Condor (newer protocol, e50ba3c0-…): no equivalent read-probe
       // char exists on V4 (HX742X) — Protocol Config (e50b0005) is
@@ -599,7 +605,11 @@ void SonicareCoordinator::on_gattc_event(esp_gattc_cb_event_t event,
         auto handle_state = espbt::ESPBTUUID::from_raw(
             "477ea600-a260-11e4-ae37-0002a5d54010");
         auto *chr = this->parent_->get_characteristic(sonicare_svc, handle_state);
-        if (chr) {
+        if (chr && this->peer_is_bonded_ && !this->encryption_requested_) {
+          ESP_LOGI(this->log_tag_.c_str(),
+                   "Bonded Classic peer — eagerly initiating SMP encryption");
+          this->request_encryption_(ESP_BLE_SEC_ENCRYPT);
+        } else if (chr) {
           this->probe_handle_ = chr->handle;
           esp_ble_gattc_read_char(
               this->parent_->get_gattc_if(),
@@ -612,10 +622,7 @@ void SonicareCoordinator::on_gattc_event(esp_gattc_cb_event_t event,
               this->pair_mode_active_ && !this->auth_completed_) {
             ESP_LOGI(this->log_tag_.c_str(),
                      "Condor service detected — initiating SMP encryption");
-            this->encryption_requested_ = true;
-            this->apply_smp_params_();
-            esp_ble_set_encryption(this->parent_->get_remote_bda(),
-                                    ESP_BLE_SEC_ENCRYPT);
+            this->request_encryption_(ESP_BLE_SEC_ENCRYPT);
           }
         }
       }
@@ -726,10 +733,7 @@ void SonicareCoordinator::on_gattc_event(esp_gattc_cb_event_t event,
                    param->read.status == ESP_GATT_INSUF_ENCRYPTION) {
           ESP_LOGW(this->log_tag_.c_str(), "Pairing probe: device requires BLE bonding (status=%d) — initiating pairing",
                    param->read.status);
-          this->encryption_requested_ = true;
-          this->apply_smp_params_();
-          esp_ble_set_encryption(this->parent_->get_remote_bda(),
-                                  ESP_BLE_SEC_ENCRYPT_MITM);
+          this->request_encryption_(ESP_BLE_SEC_ENCRYPT_MITM);
         } else {
           ESP_LOGD(this->log_tag_.c_str(), "Pairing probe failed, status=%d", param->read.status);
         }
@@ -744,7 +748,8 @@ void SonicareCoordinator::on_gattc_event(esp_gattc_cb_event_t event,
         //     ``retry_read_after_auth_`` slot to retry the original read on
         //     AUTH_CMPL.
         //   - Encryption already in flight (parallel reads racing the SMP
-        //     handshake): hand the read back to read_characteristic, which
+        //     handshake — common when eager encryption was kicked off in
+        //     SEARCH_CMPL): hand the read back to read_characteristic, which
         //     re-queues it via the pending_handle_ gate so AUTH_CMPL can
         //     drain it. Each read must be rescued individually because
         //     retry_read_after_auth_ only tracks a single in-flight read.
@@ -755,11 +760,8 @@ void SonicareCoordinator::on_gattc_event(esp_gattc_cb_event_t event,
                      "Read requires authentication (status=%d) — initiating "
                      "encryption, will retry on AUTH_CMPL",
                      param->read.status);
-            this->encryption_requested_ = true;
             this->retry_read_after_auth_ = true;
-            this->apply_smp_params_();
-            esp_ble_set_encryption(this->parent_->get_remote_bda(),
-                                    ESP_BLE_SEC_ENCRYPT_MITM);
+            this->request_encryption_(ESP_BLE_SEC_ENCRYPT_MITM);
           } else {
             ESP_LOGD(this->log_tag_.c_str(),
                      "Read of %s raced SMP — requeuing for AUTH_CMPL",
@@ -970,6 +972,19 @@ void SonicareCoordinator::on_gap_event(esp_gap_ble_cb_event_t event,
           std::string svc = this->pending_service_uuid_;
           std::string chr = this->pending_char_uuid_;
           this->read_characteristic(svc, chr);
+        } else {
+          // No single in-flight read was sitting on retry_read_after_auth_
+          // (eager-encryption path on a bonded peer), but reads might have
+          // raced the SMP handshake and landed in pending_calls_ via the
+          // INSUF_AUTH requeue branch in READ_CHAR_EVT. Clear the encryption
+          // flag so future faults can re-arm SMP, and drain whatever's queued.
+          this->encryption_requested_ = false;
+          if (!this->pending_calls_.empty()) {
+            ESP_LOGD(this->log_tag_.c_str(),
+                     "AUTH_CMPL: draining %u read(s) that raced SMP",
+                     (unsigned) this->pending_calls_.size());
+            this->drain_next_pending_call_();
+          }
         }
       } else {
         ESP_LOGW(this->log_tag_.c_str(), "Authentication FAILED (reason=0x%X)", auth.fail_reason);
@@ -1026,6 +1041,11 @@ void SonicareCoordinator::drain_next_pending_call_() {
   next();
 }
 
+void SonicareCoordinator::request_encryption_(esp_ble_sec_act_t sec_act) {
+  this->encryption_requested_ = true;
+  this->apply_smp_params_();
+  esp_ble_set_encryption(this->parent_->get_remote_bda(), sec_act);
+}
 
 void SonicareCoordinator::read_characteristic(const std::string &service_uuid,
                                                 const std::string &char_uuid) {

--- a/esphome/components/philips_sonicare/coordinator.cpp
+++ b/esphome/components/philips_sonicare/coordinator.cpp
@@ -515,6 +515,7 @@ void SonicareCoordinator::on_gattc_event(esp_gattc_cb_event_t event,
       this->pending_service_uuid_.clear();
       this->retry_read_after_auth_ = false;
       this->encryption_requested_ = false;
+      this->consecutive_auth_completes_ = 0;
       this->name_handle_ = 0;
       this->notify_map_.clear();
       this->cccd_map_.clear();
@@ -794,6 +795,7 @@ void SonicareCoordinator::on_gattc_event(esp_gattc_cb_event_t event,
         this->emit_data_(this->pending_char_uuid_, hex_payload);
 
         this->pending_handle_ = 0;
+        this->consecutive_auth_completes_ = 0;
         this->drain_next_pending_call_();
       }
       break;
@@ -927,6 +929,24 @@ void SonicareCoordinator::on_gap_event(esp_gap_ble_cb_event_t event,
         this->auth_completed_ = true;
         this->rapid_disconnect_count_ = 0;
         this->auth_fail_count_ = 0;
+
+        // Wedge detector: if AUTH_CMPL keeps succeeding without any read
+        // landing between them, SMP is looping (encryption applied, reads
+        // still return INSUF_AUTH). Drop the link so the next reconnect
+        // starts clean. Counter resets on a successful read.
+        if (++this->consecutive_auth_completes_ >
+            MAX_CONSECUTIVE_AUTH_COMPLETES) {
+          ESP_LOGW(this->log_tag_.c_str(),
+                   "SMP-success/read-INSUF_AUTH loop detected (%u) — "
+                   "forcing disconnect",
+                   this->consecutive_auth_completes_);
+          this->retry_read_after_auth_ = false;
+          this->pending_char_uuid_.clear();
+          this->pending_service_uuid_.clear();
+          this->pending_calls_.clear();
+          esp_ble_gap_disconnect(auth.bd_addr);
+          break;
+        }
         // Fresh bond just landed in NVS — re-read so subsequent writes use
         // AUTH_REQ_NO_MITM. identity_address_ may still be empty on a brand-
         // new pair (set a few lines below); the second refresh after assignment
@@ -988,14 +1008,23 @@ void SonicareCoordinator::on_gap_event(esp_gap_ble_cb_event_t event,
         }
       } else {
         ESP_LOGW(this->log_tag_.c_str(), "Authentication FAILED (reason=0x%X)", auth.fail_reason);
+        // Queued reads can't make progress after auth failure: draining one
+        // would just re-fire it, hit INSUF_AUTH against the now-unencrypted
+        // link, and either re-queue (encryption_requested_ still true) or
+        // start a fresh SMP attempt against the wiped bond. Clear instead;
+        // HA's per-read futures time out at 5 s, matching the auth-backoff
+        // path's HA-side behavior.
+        if (!this->pending_calls_.empty()) {
+          ESP_LOGD(this->log_tag_.c_str(),
+                   "AUTH_CMPL failure: discarding %u queued read(s)",
+                   (unsigned) this->pending_calls_.size());
+          this->pending_calls_.clear();
+        }
         if (this->retry_read_after_auth_ && !this->pending_char_uuid_.empty()) {
           this->emit_data_(this->pending_char_uuid_, "", "auth_failed");
           this->retry_read_after_auth_ = false;
           this->pending_char_uuid_.clear();
           this->pending_service_uuid_.clear();
-          // Don't leave queued reads stranded — they'll likely fail too
-          // (same encrypted link) but at least HA's futures resolve.
-          this->drain_next_pending_call_();
         }
         esp_ble_remove_bond_device(auth.bd_addr);
         // Pair-mode: user just asked to bond. Don't enter the auth-backoff

--- a/esphome/components/philips_sonicare/coordinator.cpp
+++ b/esphome/components/philips_sonicare/coordinator.cpp
@@ -757,6 +757,7 @@ void SonicareCoordinator::on_gattc_event(esp_gattc_cb_event_t event,
                  this->pending_char_uuid_.c_str(), param->read.status);
         this->emit_data_(this->pending_char_uuid_, "", "read_failed");
         this->pending_handle_ = 0;
+        this->drain_next_pending_call_();
         break;
       }
 
@@ -771,6 +772,7 @@ void SonicareCoordinator::on_gattc_event(esp_gattc_cb_event_t event,
         this->emit_data_(this->pending_char_uuid_, hex_payload);
 
         this->pending_handle_ = 0;
+        this->drain_next_pending_call_();
       }
       break;
     }
@@ -956,6 +958,9 @@ void SonicareCoordinator::on_gap_event(esp_gap_ble_cb_event_t event,
           this->retry_read_after_auth_ = false;
           this->pending_char_uuid_.clear();
           this->pending_service_uuid_.clear();
+          // Don't leave queued reads stranded — they'll likely fail too
+          // (same encrypted link) but at least HA's futures resolve.
+          this->drain_next_pending_call_();
         }
         esp_ble_remove_bond_device(auth.bd_addr);
         // Pair-mode: user just asked to bond. Don't enter the auth-backoff
@@ -993,6 +998,15 @@ void SonicareCoordinator::on_gap_event(esp_gap_ble_cb_event_t event,
   }
 }
 
+void SonicareCoordinator::drain_next_pending_call_() {
+  if (this->pending_calls_.empty())
+    return;
+  auto next = std::move(this->pending_calls_.front());
+  this->pending_calls_.pop_front();
+  next();
+}
+
+
 void SonicareCoordinator::read_characteristic(const std::string &service_uuid,
                                                 const std::string &char_uuid) {
   if (!this->connected_) {
@@ -1000,14 +1014,18 @@ void SonicareCoordinator::read_characteristic(const std::string &service_uuid,
     this->emit_data_(char_uuid, "", "not_connected");
     return;
   }
-  if (!this->services_discovered_) {
+  // Defer when either (a) service discovery hasn't completed, or (b) another
+  // read is in flight — ``pending_handle_`` is a single slot and concurrent
+  // reads would clobber each other's response routing.
+  if (!this->services_discovered_ || this->pending_handle_ != 0) {
     if (this->pending_calls_.size() >= MAX_PENDING_CALLS) {
       ESP_LOGW(this->log_tag_.c_str(), "Pending queue full — dropping read for %s", char_uuid.c_str());
       this->emit_data_(char_uuid, "", "queue_full");
       return;
     }
-    ESP_LOGD(this->log_tag_.c_str(), "Queueing read of %s until service discovery completes",
-             char_uuid.c_str());
+    ESP_LOGD(this->log_tag_.c_str(), "Queueing read of %s (%s)",
+             char_uuid.c_str(),
+             this->services_discovered_ ? "another read in flight" : "awaiting service discovery");
     this->pending_calls_.push_back(
         [this, service_uuid, char_uuid]() { this->read_characteristic(service_uuid, char_uuid); });
     return;

--- a/esphome/components/philips_sonicare/coordinator.cpp
+++ b/esphome/components/philips_sonicare/coordinator.cpp
@@ -738,19 +738,39 @@ void SonicareCoordinator::on_gattc_event(esp_gattc_cb_event_t event,
       }
 
       if (param->read.status != ESP_GATT_OK) {
-        // Insufficient Authentication / Encryption → initiate pairing
-        // and retry the read after successful auth (don't report error yet)
-        if ((param->read.status == ESP_GATT_INSUF_AUTHENTICATION ||
-             param->read.status == ESP_GATT_INSUF_ENCRYPTION) &&
-            !this->encryption_requested_) {
-          ESP_LOGI(this->log_tag_.c_str(), "Read requires authentication (status=%d) — initiating encryption, will retry on AUTH_CMPL",
-                   param->read.status);
-          this->encryption_requested_ = true;
-          this->retry_read_after_auth_ = true;
+        // Insufficient Authentication / Encryption: re-key the link, then
+        // retry. Two sub-paths:
+        //   - No encryption requested yet → start it and use the
+        //     ``retry_read_after_auth_`` slot to retry the original read on
+        //     AUTH_CMPL.
+        //   - Encryption already in flight (parallel reads racing the SMP
+        //     handshake): hand the read back to read_characteristic, which
+        //     re-queues it via the pending_handle_ gate so AUTH_CMPL can
+        //     drain it. Each read must be rescued individually because
+        //     retry_read_after_auth_ only tracks a single in-flight read.
+        if (param->read.status == ESP_GATT_INSUF_AUTHENTICATION ||
+            param->read.status == ESP_GATT_INSUF_ENCRYPTION) {
+          if (!this->encryption_requested_) {
+            ESP_LOGI(this->log_tag_.c_str(),
+                     "Read requires authentication (status=%d) — initiating "
+                     "encryption, will retry on AUTH_CMPL",
+                     param->read.status);
+            this->encryption_requested_ = true;
+            this->retry_read_after_auth_ = true;
+            this->apply_smp_params_();
+            esp_ble_set_encryption(this->parent_->get_remote_bda(),
+                                    ESP_BLE_SEC_ENCRYPT_MITM);
+          } else {
+            ESP_LOGD(this->log_tag_.c_str(),
+                     "Read of %s raced SMP — requeuing for AUTH_CMPL",
+                     this->pending_char_uuid_.c_str());
+            // read_characteristic auto-queues while pending_handle_ != 0,
+            // so call it before clearing the handle. It also handles the
+            // MAX_PENDING_CALLS overflow and queue_full emit for us.
+            this->read_characteristic(this->pending_service_uuid_,
+                                      this->pending_char_uuid_);
+          }
           this->pending_handle_ = 0;
-          this->apply_smp_params_();
-          esp_ble_set_encryption(this->parent_->get_remote_bda(),
-                                  ESP_BLE_SEC_ENCRYPT_MITM);
           break;
         }
         ESP_LOGW(this->log_tag_.c_str(), "Read failed for %s, status=%d",

--- a/esphome/components/philips_sonicare/coordinator.h
+++ b/esphome/components/philips_sonicare/coordinator.h
@@ -243,6 +243,14 @@ class SonicareCoordinator {
   static const uint8_t MAX_AUTH_FAILURES = 3;
   static const uint32_t AUTH_BACKOFF_MS = 60000;  // 60 seconds
 
+  // Bounds the rare "SMP succeeds but reads still return INSUF_AUTH" wedge.
+  // Each AUTH_CMPL success increments; a successful read resets. If the
+  // counter exceeds the threshold the link is stuck pumping SMP without
+  // ever delivering a read — force a disconnect so the next reconnect can
+  // recover from a clean slate.
+  uint8_t consecutive_auth_completes_{0};
+  static const uint8_t MAX_CONSECUTIVE_AUTH_COMPLETES = 3;
+
   // Helpers
   void resubscribe_all_();
   void apply_smp_params_();

--- a/esphome/components/philips_sonicare/coordinator.h
+++ b/esphome/components/philips_sonicare/coordinator.h
@@ -219,6 +219,7 @@ class SonicareCoordinator {
 
   // Encryption: only request after INSUF_AUTH on read (not unconditionally)
   bool encryption_requested_{false};
+  void request_encryption_(esp_ble_sec_act_t sec_act);
 
   // True when the peer identity is in the ESP-IDF bond NVS. Used by
   // write_characteristic to decide auth_req: bonded → AUTH_REQ_NO_MITM

--- a/esphome/components/philips_sonicare/coordinator.h
+++ b/esphome/components/philips_sonicare/coordinator.h
@@ -210,10 +210,12 @@ class SonicareCoordinator {
   uint32_t notify_throttle_ms_{500};
   std::map<uint16_t, uint32_t> last_notify_ms_;
 
-  // HA service calls that arrived between OPEN_EVT and SEARCH_CMPL_EVT.
-  // Drained in order after service discovery completes.
+  // HA service calls that arrived between OPEN_EVT and SEARCH_CMPL_EVT, or
+  // were deferred because another GATT read was already in flight. Drained
+  // one at a time so concurrent reads don't clobber pending_handle_.
   std::deque<std::function<void()>> pending_calls_;
   static const size_t MAX_PENDING_CALLS = 64;
+  void drain_next_pending_call_();
 
   // Encryption: only request after INSUF_AUTH on read (not unconditionally)
   bool encryption_requested_{false};

--- a/esphome/esp32-generic.yaml
+++ b/esphome/esp32-generic.yaml
@@ -1,8 +1,14 @@
 esphome:
   name: esp32-ble-bridge
   friendly_name: "ESP32 BLE Bridge"
-  # Uncomment to enable bluetooth_proxy (requires bluedroid_null_fix.py
-  # in your ESPHome config directory — see bottom of this file):
+  # Optional: bluedroid_null_fix.py cherry-picks the NULL pointer guards
+  # from ESP-IDF commit d4f3517 into the build. Uncomment the
+  # platformio_options block below if you opt into either:
+  #   - CONFIG_BT_GATTC_CACHE_NVS_FLASH (see sdkconfig_options below)
+  #   - bluetooth_proxy: (see end of file)
+  # Both crash on ESP-IDF 5.5's bluedroid GATT cache path without the
+  # patch. Place the script next to this YAML in your ESPHome config dir.
+  #
   # platformio_options:
   #   extra_scripts:
   #     - pre:/config/esphome/bluedroid_null_fix.py
@@ -17,6 +23,13 @@ esp32:
     sdkconfig_options:
       CONFIG_BT_GATTC_MAX_CACHE_CHAR: "80"    # default 40; Sonicare has ~45 attributes
       CONFIG_BT_GATTC_NOTIF_REG_MAX: "20"     # default 5; we subscribe to 11 chars
+      # Optional: persist discovered GATT DB to NVS keyed by bonded peer
+      # identity. First connect still does a full ~4s SDP; subsequent
+      # reconnects to the same brush hit the cache in tens of ms. Requires
+      # the bluedroid_null_fix.py pre-script (uncomment platformio_options
+      # at the top of this file) — without it the cache-save path crashes
+      # inside bta_gattc_cache_save on ESP-IDF 5.5.
+      # CONFIG_BT_GATTC_CACHE_NVS_FLASH: "y"
 
 logger:
   level: DEBUG
@@ -103,14 +116,11 @@ philips_sonicare:
 #     pin: GPIO2
 
 # --- Bluetooth Proxy (optional) ---
-# bluetooth_proxy requires a workaround for ESP-IDF bug
-# https://github.com/esphome/esphome/issues/15783
-#
-# To enable, uncomment bluetooth_proxy below AND add the pre-build
-# patch to esphome: platformio_options (see top of this file).
-# The patch fixes a NULL pointer crash in the Bluedroid BLE stack
-# that occurs during GATT service discovery when bluetooth_proxy
-# registers multiple GATT client interfaces.
+# Uncomment to relay BLE for other devices through this ESP. Requires the
+# bluedroid_null_fix.py patch (uncomment platformio_options at the top of
+# this file) to dodge ESP-IDF bug
+# https://github.com/esphome/esphome/issues/15783 — without the patch,
+# every GATT service discovery crashes the chip.
 #
 # bluetooth_proxy:
 #   active: true


### PR DESCRIPTION
## Summary

Cuts post-connect lag on bonded Classic Sonicares from ~7-8s to ~2-3s end-to-end. The three improvements below attack the two dominant costs (GATT service discovery and the SMP+serial-reads sequence) and tighten the state machine that parallelisation exposes.

| Improvement | What it cuts | Saving per reconnect |
|---|---|---|
| 1. Pipeline post-SDP reads | Serial initial-poll over ~13 chars (~100 ms BLE + 15-25 ms HA each) | ~250-500 ms |
| 2. Eager SMP on `SEARCH_CMPL` | Probe-read + INSUF_AUTH failure path before SMP | ~2 s |
| 3. Persist GATT DB to NVS | Full ~4 s SDP on every reconnect (cache-miss only on first) | ~4 s after first connect |
| **Total** | | **~7-8 s → ~2-3 s** |

A user-visible correctness fix rides along with Improvement 1: entity states (notably the Activity binary_sensor) now reflect reality on the first connect, instead of getting stuck on stale values when the initial-poll reads race the SMP handshake.

---

## Improvement 1 — Pipeline the post-SDP read pass (`ef4a957`, `4d36e64`)

Two commits, one logical change. `ef4a957` pipelines the reads, `4d36e64` rescues reads racing the SMP handshake the pipeline creates. Neither ships alone: pipelining without rescue silently drops most reads in HA's initial poll, and rescue without pipelining is dead code.

### The cost being attacked

After ESP service discovery completes (~4s on Sonicare), the Home Assistant coordinator runs an initial read pass over ~13 characteristics before live monitoring kicks in. Each round-trip is ~100 ms of BLE plus 15-25 ms of HA event-loop overhead, all serial. That pass alone was ~1.5-2 s of lag.

### Pipelining

The bridge had a `pending_calls_` FIFO, but only used it for pre-SDP queueing. Post-SDP, every read went through the single-slot `pending_handle_`, so firing concurrent reads from HA silently clobbered in-flight `GATT_READ_EVT`s.

Firmware (`coordinator.cpp`):

- `read_characteristic` now defers via `pending_calls_` when `pending_handle_ != 0`, reusing the existing FIFO.
- New `drain_next_pending_call_()` helper, called from every read-completion path (success, read_failed, auth_failed), so the queue cascades through itself.
- The existing post-SDP drain still iterates `pending_calls_` and fires every queued call back-to-back. With the defer-if-busy gate in place, the first call hits BLE and the rest land back on the queue, picked up one at a time as reads complete.

HA-side (`transport.py`):

- `EspBridgeTransport.read_chars` now uses `asyncio.gather` over `read_char` directly (which already returns `None` on failure). All reads queue on the bridge simultaneously and complete back-to-back at BLE pace.

### Rescuing reads that race the SMP handshake

**Symptom before the rescue commit.** The Activity binary_sensor (and other initial-poll-backed entities) showed stale values after a brush wake-up. The `handle_state` read landed mid-SMP, failed permanently, HA's future resolved to None, and the sensor stayed "off" until the next coordinator refresh: minutes later, or never.

**Cause.** Sonicare re-keys on every fresh GATT connect, so all 13 parallel reads land unencrypted. The pre-existing INSUF_AUTH branch was single-shot, guarded by `!encryption_requested_`, so the first racer started SMP and the other 12 fell through to the generic failure path. Permanent fail, no retry.

**Fix.** Split the INSUF_AUTH branch by whether encryption is already in flight, and reuse the pipelining commit's `pending_handle_ != 0` auto-queue gate so each racing read rescues itself:

```cpp
if (INSUF_AUTH || INSUF_ENCRYPTION) {
    if (!encryption_requested_) {
        // first racer: start SMP, single-slot retry as before
        encryption_requested_ = true;
        retry_read_after_auth_ = true;
        apply_smp_params_();
        esp_ble_set_encryption(...);
    } else {
        // subsequent racers: re-enter read_characteristic BEFORE clearing
        // pending_handle_, so pending_handle_ != 0 forces the read onto
        // pending_calls_ via the pipelining auto-queue gate
        read_characteristic(pending_service_uuid_, pending_char_uuid_);
    }
    pending_handle_ = 0;
    break;
}
```

`retry_read_after_auth_` stays single-slot; `pending_calls_` holds the rest. When `AUTH_CMPL` succeeds, its drain pops every queued read on the now-encrypted link. One queue, two roles: pipelining uses it for "bridge is busy", rescue uses it for "encryption is in flight".

### Net effect

Roughly 250-500 ms saved on the initial read pass. Every read in HA's initial poll survives the SMP race, so entity states reflect reality on the first connect.

---

## Improvement 2 — Eager SMP on `SEARCH_CMPL` for bonded Classic peers (`6a64afb`, `0268d85`)

### The cost being attacked

After `SEARCH_CMPL_EVT`, the bridge used to fire a probe-read on Handle State to detect whether the link needed re-encryption. Sonicare always re-keys on fresh GATT connect even though both sides hold the bond, so the probe always failed with INSUF_AUTH, the failure handler triggered SMP, and the handshake added ~2s to every reconnect.

### Fix

For bonded Classic peers, skip the probe and call `esp_ble_set_encryption(...)` directly from `SEARCH_CMPL_EVT`. Open-GATT brushes (HX6340 Kids, etc.) and not-yet-bonded peers keep the probe-read path; they don't yet know whether encryption is needed.

The triplet `encryption_requested_ = true; apply_smp_params_(); esp_ble_set_encryption(...)` previously appeared at 3 sites; this would have made 4. Consolidated into `request_encryption_(sec_act)` and migrated all four call sites.

### State-machine fallout closed by the follow-up commit

Eager encryption fires SMP before HA's initial poll arrives, so reads land mid-handshake more often than via the probe path. The rescue path from Improvement 1 covers the read side. `AUTH_CMPL` needed three fixes:

1. **New success branch for the eager path.** The eager path doesn't set `retry_read_after_auth_`, so the existing `AUTH_CMPL` success branch wouldn't fire. Added an `else` branch that clears `encryption_requested_` and drains `pending_calls_`.

2. **Stale-pending-calls on failure.** `AUTH_CMPL` failure left `pending_calls_` populated when no read was sitting on `retry_read_after_auth_` (the eager-SMP-on-bonded-peer path). The existing single `drain_next_pending_call_` made no progress: the drained lambda re-fired, hit INSUF_AUTH against the now-unencrypted link, and re-queued itself because `encryption_requested_` was never cleared on failure. HA's per-read 5s timeouts resolved the futures eventually, but the queue held stale lambdas until the next disconnect. Replaced the no-op drain with an unconditional `pending_calls_.clear()`.

3. **Pump loop on RPA rotation.** If SMP succeeds but reads still return INSUF_AUTH (rare; some IDF versions after RPA rotation), `AUTH_CMPL` success drains a read → INSUF_AUTH → `request_encryption_` → `AUTH_CMPL` again, indefinitely. `auth_fail_count_` only tracks failures, so it never tripped. Added `consecutive_auth_completes_`: bumped at `AUTH_CMPL` success, reset on any successful read and on disconnect. Past `MAX_CONSECUTIVE_AUTH_COMPLETES` (3) the link is wedged: clear pending state and `esp_ble_gap_disconnect`.

### Net effect

~2s saved on every reconnect for bonded Classic peers. State machine no longer leaks stale queue entries on auth failure or spins on the rare RPA-rotation case.

---

## Improvement 3 — Persist GATT DB to NVS (`e8067ff`)

### The cost being attacked

GATT service discovery on Sonicare takes ~4s, the dominant single cost in reconnect lag. Bluedroid supports persisting the discovered GATT DB to NVS keyed by bonded peer identity (`CONFIG_BT_GATTC_CACHE_NVS_FLASH`), but it had been left off, so every reconnect re-ran the full SDP.

### Fix

Enable `CONFIG_BT_GATTC_CACHE_NVS_FLASH=y`. First connect still pays the full ~4s SDP cost; subsequent reconnects to the same bonded brush hit the cache in tens of ms.

### IDF 5.5 crash workaround

Enabling the flag triggers a crash inside `bta_gattc_cache_save` on ESP-IDF 5.5: a null deref in the cache-save path. Wired in `bluedroid_null_fix.py` via `esphome.platformio_options.extra_scripts` to patch at build time. The same script also covers the `bluetooth_proxy` coexistence crash (#15783), so the `bluetooth_proxy` comment block at the bottom of each reference YAML is simplified from a multi-line warning to a single-line opt-in.

### Rollout requirement

Users need to drop `bluedroid_null_fix.py` next to their YAML (HAOS: `/config/esphome/`) and re-flash both bridges. Applied to all three reference configs.

### Net effect

~4s saved on every reconnect after the first one. Combined with Improvement 2, end-to-end reconnect drops from ~7-8s to ~2-3s on a bonded Classic Sonicare.

---

## Test plan

- [ ] Reconnect a bonded Classic Sonicare (HX9xxx). Confirm ~2-3s end-to-end vs ~7-8s baseline.
- [ ] First reconnect after flash still completes (cache-miss path; full SDP cost).
- [ ] Second reconnect hits the NVS cache (tens of ms SDP, not seconds).
- [ ] Open-GATT brush (HX6340 Kids) still pairs via probe-read path.
- [ ] **Activity binary_sensor reflects brush state correctly within the first connect** (Improvement 1 rescue-path regression).
- [ ] No dropped reads under the initial-poll parallel-fire; every entity backed by the initial read pass populates within the first connect.
- [ ] Watch logs for `consecutive_auth_completes_` cap firing. Should be rare or absent.
- [ ] `bluetooth_proxy` coexistence still works on the relevant bridge.
- [ ] `bluedroid_null_fix.py` build patch applies cleanly on a clean ESPHome build.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
