### PR TITLE
Added counterfit detection

### DIFF
--- a/custom_components/philips_sonicare_ble/binary_sensor.py
+++ b/custom_components/philips_sonicare_ble/binary_sensor.py
@@ -13,8 +13,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity import EntityCategory
 
 from .coordinator import PhilipsSonicareCoordinator
-from .entity import PhilipsSonicareEntity, PhilipsConnectionEntity
-from .const import DOMAIN, CONF_SERVICES, CONF_TRANSPORT_TYPE, SVC_SENSOR, TRANSPORT_ESP_BRIDGE
+from .entity import PhilipsSonicareEntity, PhilipsBrushHeadEntity, PhilipsConnectionEntity
+from .const import DOMAIN, CONF_SERVICES, CONF_TRANSPORT_TYPE, SVC_SENSOR, SVC_BRUSHHEAD, SVC_CONDOR, TRANSPORT_ESP_BRIDGE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,6 +35,10 @@ async def async_setup_entry(
     # Pressure alert requires Sensor/IMU service
     if SVC_SENSOR.lower() in services:
         entities.append(SonicarePressureAlertBinarySensor(coordinator, entry))
+
+    # Counterfeit brush head sensor (brush head sub-device)
+    if SVC_BRUSHHEAD.lower() in services or SVC_CONDOR.lower() in services:
+        entities.append(SonicareBrushHeadCounterfeitSensor(coordinator, entry))
 
     # Connection sub-device sensors
     entities.append(SonicareBleConnectedSensor(coordinator, entry))
@@ -159,3 +163,33 @@ class SonicareBleConnectedSensor(PhilipsConnectionEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         return self.coordinator.transport.is_device_connected
+
+
+class SonicareBrushHeadCounterfeitSensor(PhilipsBrushHeadEntity, BinarySensorEntity):
+    """Binary sensor that turns on when a counterfeit brush head is suspected.
+
+    Raises after 30 seconds of active brushing with no valid NFC serial.
+    Clears immediately when a valid serial is detected.
+    """
+
+    _attr_translation_key = "brushhead_counterfeit"
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:shield-alert-outline"
+    _data_key = "brushhead_counterfeit"
+
+    def __init__(
+        self, coordinator: PhilipsSonicareCoordinator, entry: ConfigEntry
+    ) -> None:
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"{self._device_id}_brushhead_counterfeit"
+
+    @property
+    def is_on(self) -> bool:
+        if not self.coordinator.data:
+            return False
+        return bool(self.coordinator.data.get("brushhead_counterfeit", False))
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.data is not None

--- a/custom_components/philips_sonicare_ble/config_flow.py
+++ b/custom_components/philips_sonicare_ble/config_flow.py
@@ -41,12 +41,14 @@ from .const import (
     CONF_SENSOR_PRESSURE,
     CONF_SENSOR_TEMPERATURE,
     CONF_SENSOR_GYROSCOPE,
+    CONF_WARN_COUNTERFEIT,
     TRANSPORT_BLEAK,
     TRANSPORT_ESP_BRIDGE,
     DEFAULT_NOTIFY_THROTTLE,
     DEFAULT_SENSOR_PRESSURE,
     DEFAULT_SENSOR_TEMPERATURE,
     DEFAULT_SENSOR_GYROSCOPE,
+    DEFAULT_WARN_COUNTERFEIT,
     MIN_NOTIFY_THROTTLE,
     MAX_NOTIFY_THROTTLE,
     CHAR_BATTERY_LEVEL,
@@ -1938,6 +1940,7 @@ class PhilipsSonicareOptionsFlow(OptionsFlow):
                 CONF_SENSOR_PRESSURE: user_input.get(CONF_SENSOR_PRESSURE, DEFAULT_SENSOR_PRESSURE),
                 CONF_SENSOR_TEMPERATURE: user_input.get(CONF_SENSOR_TEMPERATURE, DEFAULT_SENSOR_TEMPERATURE),
                 CONF_SENSOR_GYROSCOPE: user_input.get(CONF_SENSOR_GYROSCOPE, DEFAULT_SENSOR_GYROSCOPE),
+                CONF_WARN_COUNTERFEIT: user_input.get(CONF_WARN_COUNTERFEIT, DEFAULT_WARN_COUNTERFEIT),
             }
             if is_esp:
                 if CONF_NOTIFY_THROTTLE in user_input:
@@ -1957,6 +1960,10 @@ class PhilipsSonicareOptionsFlow(OptionsFlow):
         schema_fields[vol.Required(
                 CONF_SENSOR_GYROSCOPE,
                 default=options.get(CONF_SENSOR_GYROSCOPE, DEFAULT_SENSOR_GYROSCOPE),
+            )] = bool
+        schema_fields[vol.Required(
+                CONF_WARN_COUNTERFEIT,
+                default=options.get(CONF_WARN_COUNTERFEIT, DEFAULT_WARN_COUNTERFEIT),
             )] = bool
 
         if is_esp:

--- a/custom_components/philips_sonicare_ble/const.py
+++ b/custom_components/philips_sonicare_ble/const.py
@@ -510,3 +510,10 @@ CONF_SENSOR_GYROSCOPE = "sensor_gyroscope"
 DEFAULT_SENSOR_PRESSURE = True
 DEFAULT_SENSOR_TEMPERATURE = True
 DEFAULT_SENSOR_GYROSCOPE = False
+
+CONF_WARN_COUNTERFEIT = "warn_counterfeit_brushhead"
+DEFAULT_WARN_COUNTERFEIT = True
+# All-zero serial reported when no valid NFC chip is detected on the brush head
+COUNTERFEIT_SERIAL = "00:00:00:00:00:00:00"
+# Seconds of active brushing before a missing/invalid serial raises an alert
+COUNTERFEIT_DETECTION_DELAY = 30

--- a/custom_components/philips_sonicare_ble/coordinator.py
+++ b/custom_components/philips_sonicare_ble/coordinator.py
@@ -79,6 +79,10 @@ from .const import (
     MIN_BRIDGE_VERSION,
     CONF_NOTIFY_THROTTLE,
     DEFAULT_NOTIFY_THROTTLE,
+    CONF_WARN_COUNTERFEIT,
+    DEFAULT_WARN_COUNTERFEIT,
+    COUNTERFEIT_SERIAL,
+    COUNTERFEIT_DETECTION_DELAY,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -166,6 +170,8 @@ class PhilipsSonicareCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._last_adapter_type: str | None = None
         self._unsub_adv_debug = None
         self._dbus_bus: MessageBus | None = None
+        self._counterfeit_timer_task: asyncio.Task | None = None
+        self._counterfeit_detected: bool = False
         # HA >= 2026.5 exposes async_clear_advertisement_history — preferred over
         # the BlueZ D-Bus RSSI listener for waking on static-ADV devices.
         self._use_adv_clear = hasattr(
@@ -232,6 +238,7 @@ class PhilipsSonicareCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "temperature": None,
             "handle_time": None,
             "last_seen": None,
+            "brushhead_counterfeit": False,
         }
 
     @property
@@ -416,20 +423,24 @@ class PhilipsSonicareCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         :meth:`async_set_updated_data` once they've confirmed a state
         transition is worth publishing.
         """
-        new_data = self.data.copy() if self.data else {}
+        old = self.data or {}
+        new_data = old.copy()
         new_data.update(parsed)
 
         # Sensor stream gates on brushing_state — Classic only, since
         # Condor never emits this key (its sensor stream rides a separate
         # Subscribe on the ``SensorData.b`` port instead of CCCD).
         if not self._use_condor and "brushing_state" in parsed:
-            old_state = (self.data or {}).get("brushing_state")
+            old_state = old.get("brushing_state")
             new_state = parsed["brushing_state"]
             if new_state != old_state:
                 if new_state == "on" and not self._sensor_subscribed:
                     self.hass.async_create_task(self._subscribe_sensor_data())
                 elif old_state == "on" and self._sensor_subscribed:
                     self.hass.async_create_task(self._unsubscribe_sensor_data())
+
+        # Counterfeit brush head detection
+        self._update_counterfeit(old, new_data)
 
         # Derived: brush head wear percentage
         limit = new_data.get("brushhead_lifetime_limit")
@@ -441,7 +452,6 @@ class PhilipsSonicareCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # Change detection: only update last_seen when data actually changed
         # or every 30s as heartbeat for availability tracking
-        old = self.data or {}
         changed = any(
             new_data.get(k) != old.get(k)
             for k in new_data
@@ -475,6 +485,125 @@ class PhilipsSonicareCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
 
         return new_data
+
+    # ------------------------------------------------------------------
+    # Counterfeit brush head detection
+    # ------------------------------------------------------------------
+
+    def _is_valid_serial(self, serial: str | None) -> bool:
+        """True when the serial represents a successfully-read NFC chip."""
+        return serial is not None and serial != COUNTERFEIT_SERIAL
+
+    def _looks_counterfeit(self, data: dict) -> bool:
+        """True when the serial indicates no valid NFC chip was read.
+
+        Type is intentionally not checked — non-genuine heads sometimes
+        report a plausible-looking type byte even without a valid serial.
+        """
+        return not self._is_valid_serial(data.get("brushhead_serial"))
+
+    def _update_counterfeit(self, old: dict, new_data: dict) -> None:
+        """Manage the counterfeit detection timer and issue state."""
+        serial = new_data.get("brushhead_serial")
+
+        # Valid serial arrived — cancel timer and clear the alert
+        if self._is_valid_serial(serial):
+            self._cancel_counterfeit_timer()
+            if self._counterfeit_detected:
+                self._counterfeit_detected = False
+                self._clear_counterfeit_issue()
+            new_data["brushhead_counterfeit"] = False
+            return
+
+        # Propagate currently-detected state into the new snapshot
+        new_data["brushhead_counterfeit"] = self._counterfeit_detected
+
+        # Only run detection when both serial and type look suspect
+        if not self._looks_counterfeit(new_data):
+            self._cancel_counterfeit_timer()
+            return
+
+        brushing_now = (
+            new_data.get("brushing_state") == "on"
+            or new_data.get("handle_state_value") == 2
+        )
+        old_brushing = (
+            old.get("brushing_state") == "on"
+            or old.get("handle_state_value") == 2
+        )
+
+        if brushing_now and not old_brushing:
+            # Brushing just started — begin 30 s countdown
+            self._start_counterfeit_timer()
+        elif not brushing_now and old_brushing:
+            # Brushing stopped before the timer fired — cancel without alerting
+            self._cancel_counterfeit_timer()
+        elif brushing_now and self._counterfeit_timer_task is None and not self._counterfeit_detected:
+            # Already brushing when we (re)connected — start timer if not running
+            self._start_counterfeit_timer()
+
+    def _start_counterfeit_timer(self) -> None:
+        """Start (or restart) the counterfeit detection countdown."""
+        self._cancel_counterfeit_timer()
+        self._counterfeit_timer_task = self.entry.async_create_background_task(
+            self.hass,
+            self._counterfeit_timer_fired(),
+            "philips_sonicare_counterfeit_timer",
+        )
+
+    def _cancel_counterfeit_timer(self) -> None:
+        """Cancel any pending counterfeit detection timer."""
+        if self._counterfeit_timer_task and not self._counterfeit_timer_task.done():
+            self._counterfeit_timer_task.cancel()
+        self._counterfeit_timer_task = None
+
+    async def _counterfeit_timer_fired(self) -> None:
+        """Fired after COUNTERFEIT_DETECTION_DELAY seconds of continuous brushing."""
+        await asyncio.sleep(COUNTERFEIT_DETECTION_DELAY)
+        if not self.data:
+            return
+        # Re-check conditions at fire time
+        if not self._looks_counterfeit(self.data):
+            return
+        brushing_now = (
+            self.data.get("brushing_state") == "on"
+            or self.data.get("handle_state_value") == 2
+        )
+        if not brushing_now:
+            return
+        _LOGGER.warning(
+            "%s: no valid brush head serial after %ds of brushing — "
+            "possible counterfeit brush head",
+            self.address,
+            COUNTERFEIT_DETECTION_DELAY,
+        )
+        self._counterfeit_detected = True
+        self.data["brushhead_counterfeit"] = True
+        self._create_counterfeit_issue()
+        self.async_set_updated_data(self.data)
+
+    def _create_counterfeit_issue(self) -> None:
+        """Raise an HA repair issue for the counterfeit brush head."""
+        if not self.entry.options.get(CONF_WARN_COUNTERFEIT, DEFAULT_WARN_COUNTERFEIT):
+            return
+        from homeassistant.helpers import issue_registry as ir
+        device_name = self.entry.data.get("device_name") or self.address
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            f"brushhead_counterfeit_{self.address}",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="brushhead_counterfeit",
+            translation_placeholders={"device": device_name},
+        )
+
+    def _clear_counterfeit_issue(self) -> None:
+        """Remove the counterfeit repair issue."""
+        from homeassistant.helpers import issue_registry as ir
+        ir.async_delete_issue(
+            self.hass, DOMAIN, f"brushhead_counterfeit_{self.address}"
+        )
 
     async def _start_live_monitoring(self) -> None:
         """Persistent live connection with notifications.
@@ -1076,6 +1205,8 @@ class PhilipsSonicareCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def async_shutdown(self) -> None:
         """Called on unload - clean up everything."""
+        self._cancel_counterfeit_timer()
+
         if self._unsub_adv_debug:
             self._unsub_adv_debug()
             self._unsub_adv_debug = None

--- a/custom_components/philips_sonicare_ble/coordinator.py
+++ b/custom_components/philips_sonicare_ble/coordinator.py
@@ -518,7 +518,7 @@ class PhilipsSonicareCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Propagate currently-detected state into the new snapshot
         new_data["brushhead_counterfeit"] = self._counterfeit_detected
 
-        # Only run detection when both serial and type look suspect
+        # Only run detection while the serial looks suspect (no valid NFC read)
         if not self._looks_counterfeit(new_data):
             self._cancel_counterfeit_timer()
             return

--- a/custom_components/philips_sonicare_ble/strings.json
+++ b/custom_components/philips_sonicare_ble/strings.json
@@ -3,6 +3,10 @@
     "esp_bridge_outdated": {
       "title": "ESP bridge firmware update required",
       "description": "Your ESP bridge is running **v{version}**, but **v{min_version}** or newer is required for full functionality.\n\nRebuild and flash your ESPHome device to get the latest firmware. See the ESP Bridge Changelog in the repository for details."
+    },
+    "brushhead_counterfeit": {
+      "title": "Possible counterfeit brush head — {device}",
+      "description": "**{device}** has been brushing for 30 seconds without detecting a valid NFC serial on the brush head.\n\nThis may indicate a counterfeit or non-genuine replacement head that lacks an NFC chip.\n\n**To resolve:** Attach a genuine Philips Sonicare brush head. The warning will clear automatically once a valid serial is detected.\n\nYou can disable this warning in the integration options."
     }
   },
   "config": {
@@ -106,13 +110,15 @@
           "sensor_pressure": "Enable pressure sensor",
           "sensor_temperature": "Enable temperature sensor",
           "sensor_gyroscope": "Enable gyroscope sensor",
-          "notify_throttle_ms": "Notification throttle (ms)"
+          "notify_throttle_ms": "Notification throttle (ms)",
+          "warn_counterfeit_brushhead": "Warn about counterfeit brush heads"
         },
         "data_description": {
           "sensor_pressure": "Stream pressure data during brushing sessions (0x01).",
           "sensor_temperature": "Stream temperature data during brushing sessions (0x02).",
           "sensor_gyroscope": "Stream 6-axis IMU data during brushing sessions (0x04). High bandwidth — may impact ESP performance.",
-          "notify_throttle_ms": "Minimum interval between BLE notification events forwarded by the ESP bridge. Lower values give faster updates but may overload the ESP. Only applies to ESP32 bridge connections."
+          "notify_throttle_ms": "Minimum interval between BLE notification events forwarded by the ESP bridge. Lower values give faster updates but may overload the ESP. Only applies to ESP32 bridge connections.",
+          "warn_counterfeit_brushhead": "Warn if no valid brush head NFC serial is detected after 30 seconds of brushing."
         }
       }
     }
@@ -249,7 +255,8 @@
       "is_charging": { "name": "Charging" },
       "pressure_alert": { "name": "Pressure Alert" },
       "esp_bridge_alive": { "name": "ESP Bridge" },
-      "ble_connected": { "name": "BLE Connected" }
+      "ble_connected": { "name": "BLE Connected" },
+      "brushhead_counterfeit": { "name": "Counterfeit Brush Head" }
     },
     "select": {
       "brushing_mode_select": {

--- a/custom_components/philips_sonicare_ble/translations/en.json
+++ b/custom_components/philips_sonicare_ble/translations/en.json
@@ -3,6 +3,10 @@
     "esp_bridge_outdated": {
       "title": "ESP bridge firmware update required",
       "description": "Your ESP bridge is running **v{version}**, but **v{min_version}** or newer is required for full functionality.\n\nRebuild and flash your ESPHome device to get the latest firmware. See the ESP Bridge Changelog in the repository for details."
+    },
+    "brushhead_counterfeit": {
+      "title": "Possible counterfeit brush head — {device}",
+      "description": "**{device}** has been brushing for 30 seconds without detecting a valid NFC serial on the brush head.\n\nThis may indicate a counterfeit or non-genuine replacement head that lacks an NFC chip.\n\n**To resolve:** Attach a genuine Philips Sonicare brush head. The warning will clear automatically once a valid serial is detected.\n\nYou can disable this warning in the integration options."
     }
   },
   "config": {
@@ -106,13 +110,15 @@
           "sensor_pressure": "Enable pressure sensor",
           "sensor_temperature": "Enable temperature sensor",
           "sensor_gyroscope": "Enable gyroscope sensor",
-          "notify_throttle_ms": "Notification throttle (ms)"
+          "notify_throttle_ms": "Notification throttle (ms)",
+          "warn_counterfeit_brushhead": "Warn about counterfeit brush heads"
         },
         "data_description": {
           "sensor_pressure": "Stream pressure data during brushing sessions (0x01).",
           "sensor_temperature": "Stream temperature data during brushing sessions (0x02).",
           "sensor_gyroscope": "Stream 6-axis IMU data during brushing sessions (0x04). High bandwidth — may impact ESP performance.",
-          "notify_throttle_ms": "Minimum interval between BLE notification events forwarded by the ESP bridge. Lower values give faster updates but may overload the ESP. Only applies to ESP32 bridge connections."
+          "notify_throttle_ms": "Minimum interval between BLE notification events forwarded by the ESP bridge. Lower values give faster updates but may overload the ESP. Only applies to ESP32 bridge connections.",
+          "warn_counterfeit_brushhead": "Warn if no valid brush head NFC serial is detected after 30 seconds of brushing."
         }
       }
     }
@@ -313,6 +319,9 @@
       },
       "ble_connected": {
         "name": "BLE Connected"
+      },
+      "brushhead_counterfeit": {
+        "name": "Counterfeit Brush Head"
       }
     },
     "select": {


### PR DESCRIPTION
Recently purchased some brushheads from eBay thinking it was a great deal. Turns out this was not the case, and they were indeed non-genuine and fall out after a few days.

On studying this, the NFC chip invariably reports Type, at times NFC payload, but serial is always 00:00:00:00:00:00:00.

This PR seeks to detect if a brush is running for 30s without a valid serial. 30s just removes any possibility of the brush head being removed/changed whilst running. 

It then surfaces a warning so the user is aware:
<img width="694" height="253" alt="image" src="https://github.com/user-attachments/assets/9ff7e9e3-3107-4ecd-b724-6e7498a3f077" />
<img width="609" height="465" alt="image" src="https://github.com/user-attachments/assets/68594dc3-9fae-4e87-aca6-740a71bcf496" />

This functionality can be dismissed via the integration settings:
<img width="627" height="604" alt="image" src="https://github.com/user-attachments/assets/84e88813-c8c2-431b-b6e2-182389a3497a" />
