### PR TITLE
Fix counterfeit false-positive on genuine Condor heads (all-zeros serial)

### DIFF
--- a/custom_components/philips_sonicare_ble/classic_protocol.py
+++ b/custom_components/philips_sonicare_ble/classic_protocol.py
@@ -325,8 +325,10 @@ class ClassicProtocol(SonicareProtocol):
             if raw := results.get(uuid):
                 out[key] = int.from_bytes(raw[:4], "little")
 
-        # Brush head identity and payload
-        if raw := results.get(CHAR_BRUSHHEAD_SERIAL):
+        # Brush head identity and payload. Only publish a real NFC read — an
+        # all-zeros serial is the "chip not scanned" placeholder (head removal
+        # is handled separately via the serial notification).
+        if (raw := results.get(CHAR_BRUSHHEAD_SERIAL)) and any(b != 0 for b in raw):
             out["brushhead_serial"] = ":".join(f"{b:02X}" for b in raw)
         if raw := results.get(CHAR_BRUSHHEAD_DATE):
             out["brushhead_date"] = raw.decode("utf-8", "ignore").strip()

--- a/custom_components/philips_sonicare_ble/condor_adapter.py
+++ b/custom_components/philips_sonicare_ble/condor_adapter.py
@@ -202,7 +202,11 @@ def _map_brush_head(props: dict[str, Any], out: dict[str, Any]) -> None:
     is a build-tag flag with no user-facing equivalent.
     """
     v = props.get("SerialNumber")
-    if isinstance(v, list) and v:
+    # Only publish a real NFC read. An all-zeros SerialNumber is the handle's
+    # "chip not scanned this cycle" placeholder — storing it would clobber a
+    # known-good serial and, via _is_valid_serial(), trip a false counterfeit
+    # alert on a genuine head. Keep the last-known value instead.
+    if isinstance(v, list) and any(b != 0 for b in v):
         out["brushhead_serial"] = ":".join(f"{b:02X}" for b in v)
     if (v := props.get("LifetimeLimit")) is not None:
         out["brushhead_lifetime_limit"] = v

--- a/custom_components/philips_sonicare_ble/coordinator.py
+++ b/custom_components/philips_sonicare_ble/coordinator.py
@@ -109,6 +109,9 @@ UNPERSISTED_KEYS = {
     "pressure_alarm",
     "pressure_state",
     "temperature",
+    # Never restore a stale counterfeit verdict across a restart — re-derive it
+    # from a live serial read instead.
+    "brushhead_counterfeit",
 }
 
 
@@ -655,6 +658,18 @@ class PhilipsSonicareCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def _update_counterfeit(self, old: dict, new_data: dict) -> None:
         """Manage the counterfeit detection timer and issue state."""
+        # Honour the user's "warn about counterfeit brush head" preference as a
+        # real off switch: when disabled, turn the whole feature off (sensor
+        # stays False, timer cancelled, any issue cleared) — not just the repair.
+        if not self.entry.options.get(CONF_WARN_COUNTERFEIT, DEFAULT_WARN_COUNTERFEIT):
+            self._cancel_counterfeit_timer()
+            if self._counterfeit_detected or not self._counterfeit_cleanup_done:
+                self._clear_counterfeit_issue()
+            self._counterfeit_detected = False
+            self._counterfeit_cleanup_done = True
+            new_data["brushhead_counterfeit"] = False
+            return
+
         # Devices without a brush-head NFC service (e.g. HX63xx Kids) never
         # report a serial — skip detection entirely so we don't flag every
         # session. Drop any issue an earlier build may have raised, once.

--- a/custom_components/philips_sonicare_ble/sensor.py
+++ b/custom_components/philips_sonicare_ble/sensor.py
@@ -659,7 +659,12 @@ class SonicareBrushHeadSerialSensor(PhilipsBrushHeadEntity, SensorEntity):
     def native_value(self) -> str | None:
         if not self.coordinator.data:
             return None
-        return self.coordinator.data.get("brushhead_serial")
+        serial = self.coordinator.data.get("brushhead_serial")
+        # Defensive: never surface the all-zeros "no chip read" placeholder as a
+        # real serial (matches the coordinator's _is_valid_serial() logic).
+        if serial and not any(c not in "0:" for c in serial):
+            return None
+        return serial
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The counterfeit brush-head detection added in #21 flags a **genuine** head as counterfeit on Condor devices (e.g. HX742X, HX999X Prestige 9900).

`#21` treats an all-zeros brush-head serial as "no valid NFC chip ⇒ counterfeit". That's a fair signal for the always-all-zeros counterfeit heads it was built against, but genuine **Condor** heads also report an all-zeros `SerialNumber` on the `BrushHead` port **between NFC scans** — and Condor has no per-notification serial re-read (the `CHAR_BRUSHHEAD_SERIAL` re-read in `_make_live_callback` is Classic-only; Condor deltas route through `_on_condor_delta` → `_apply_parsed`).

So a single transient all-zeros read **overwrites the known-good serial**, and after `COUNTERFEIT_DETECTION_DELAY` (30 s) of brushing the alert latches on a genuine head. It then sticks: `_counterfeit_detected` clears only on a later valid read, is persisted across restarts, and is re-published on reconnect. On my HX999X the serial alternates between a real value (`04:CA:…`) and `00:00:00:00:00:00:00`, and the counterfeit sensor stays `on` on a genuine Philips head.

## Fix

Treat a **transient** all-zeros read as "no NFC data this cycle", not as "no serial ever":

- **`condor_adapter._map_brush_head`** and **`classic_protocol._process_results`**: only store `brushhead_serial` when `SerialNumber` has a non-zero byte, so a real read is retained instead of being clobbered by the placeholder.
  - A genuine head (reports a real serial at least once) is **never** flagged.
  - A true counterfeit (never reports a valid serial) **still** trips the 30 s timer — detection intent preserved.
- **`coordinator`**: add `brushhead_counterfeit` to `UNPERSISTED_KEYS` so a stale verdict isn't restored across a restart.
- **`coordinator._update_counterfeit`**: honour `CONF_WARN_COUNTERFEIT` as a real off switch — when disabled it turns the whole feature off (sensor `False`, timer cancelled, issue cleared), not just the repair issue. (Currently the option only gates `_create_counterfeit_issue()`, so the binary sensor latches `on` regardless.)
- **`sensor`**: brush-head Serial returns `None` for the all-zeros placeholder instead of publishing a fake `00:00:00:00:00:00:00`.

## Notes

- Root cause is specific to Condor (no in-session serial re-read) but the serial-guard change is protocol-agnostic and harmless on Classic (head removal is still handled by the all-zeros serial *notification* → `_clear_brushhead_data`, which is unchanged).
- No new deps; byte-compiles; changes are localized to the four files above.
- Tested on an HX999X (368F) Prestige 9900 on the Condor protocol.

cc @alexw23 (author of #21) — this keeps your counterfeit detection working for the always-all-zeros fakes while stopping the false positive on genuine Condor heads.
